### PR TITLE
Remove unused emit_markers option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,9 +44,6 @@ pub struct Cli {
     #[arg(short = 'k', long = "chunk-index", default_value_t = -1)]
     pub chunk_index: isize,
 
-    /// Insert <more/> markers so an LLM knows additional chunks will follow.
-    #[arg(short = 'e', long = "emit-markers")]
-    pub emit_markers: bool,
 
     /// Enable multi-step mode: copy only header initially; then serve files on demand (use -i for TUI file picker).
     #[arg(short = 'm', long = "multi-step")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ pub struct Config {
     pub model_context: Option<usize>,
     pub chunk_size: usize,
     pub chunk_index: isize,
-    pub emit_markers: bool,
     /// Enable multi-step mode: copy only header initially and serve files on demand.
     pub multi_step: bool,
 }
@@ -34,7 +33,6 @@ impl Config {
             model_context: cli.model_context,
             chunk_size: cli.chunk_size,
             chunk_index: cli.chunk_index,
-            emit_markers: cli.emit_markers,
             multi_step: cli.multi_step,
         })
     }


### PR DESCRIPTION
## Summary
- remove the `--emit-markers` CLI option
- drop related field from `Config`

## Testing
- `cargo test --offline` *(fails: no matching package named `chrono`)*