### PR TITLE
Switch model_context to usize

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,8 +33,8 @@ pub struct Cli {
     pub exclude: Vec<String>,
 
     /// Maximum token count for model context; warn if exceeded.
-    #[arg(long = "model-context", default_value = "200000")]
-    pub model_context: Option<usize>,
+    #[arg(long = "model-context", default_value_t = 200000)]
+    pub model_context: usize,
 
     /// Split the context into chunks no larger than this many tokens (use with -i to browse chunks in TUI).
     #[arg(short = 'c', long = "chunk-size", default_value_t = DEFAULT_CHUNK_SIZE)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
     pub stdout: bool,
     pub max_size: u64,
     pub exclude: Vec<String>,
-    pub model_context: Option<usize>,
+    pub model_context: usize,
     pub chunk_size: usize,
     pub chunk_index: isize,
     pub emit_markers: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,22 +163,13 @@ fn main() -> Result<()> {
             clipboard::copy_to_clipboard(&xml_output, false)?;
         }
         // Summary: one chunk (index 0)
-        let summary = if config.stdout && config.no_clipboard && config.model_context.is_none() {
-            // Skip tokenisation for pure stdout + no-clipboard runs when no model_context
-            format!(
-                "✔ {} files • 1 chunk • copied={}",
-                file_data.len(),
-                if !config.no_clipboard { "0" } else { "none" }
-            )
-        } else {
-            let token_count = gather::count_tokens(&xml_output);
-            format!(
-                "✔ {} files • {} tokens • 1 chunk • copied={}",
-                file_data.len(),
-                token_count,
-                if !config.no_clipboard { "0" } else { "none" }
-            )
-        };
+        let token_count = gather::count_tokens(&xml_output);
+        let summary = format!(
+            "✔ {} files • {} tokens • 1 chunk • copied={}",
+            file_data.len(),
+            token_count,
+            if !config.no_clipboard { "0" } else { "none" }
+        );
         println!("{summary}");
         return Ok(());
     }
@@ -246,14 +237,12 @@ fn main() -> Result<()> {
     }
 
     // 9) Warn if token count exceeds model context limit
-    if let Some(limit) = config.model_context {
-        if count_tokens(&xml_output) > limit {
-            warn!(
-                "token count {} exceeds model context limit {}",
-                count_tokens(&xml_output),
-                limit
-            );
-        }
+    if count_tokens(&xml_output) > config.model_context {
+        warn!(
+            "token count {} exceeds model context limit {}",
+            count_tokens(&xml_output),
+            config.model_context
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- switch `model_context` to `usize` in CLI and Config
- rely on `#[arg(default_value_t = 200000)]`
- update main to use the new type

## Testing
- `cargo test --offline` *(fails: no matching package named `chrono` found)*