### PR TITLE
Remove ctrlc dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2024"
 anyhow = "1.0.95"
 copypasta = "0.10.1"
 crossterm = "0.28.1"
-ctrlc = "3"
 glob = "0.3.2"
 tiktoken-rs = "0.6.0"
 clap = { version = "4.4.6", features = ["derive"] }


### PR DESCRIPTION
## Summary
- delete unused `ctrlc` crate
- attempted `cargo check` after removal

## Testing
- `cargo check -q` *(fails: could not download crates)*