### PR TITLE
Remove emojis from warnings and output

### DIFF
--- a/src/io/clipboard.rs
+++ b/src/io/clipboard.rs
@@ -14,7 +14,7 @@ pub fn copy_to_clipboard(
             if fail_hard {
                 return Err(anyhow::anyhow!("Clipboard init failed: {:?}", e));
             } else {
-                tracing::warn!("⚠️  Clipboard unavailable: {:?}", e);
+                tracing::warn!("WARNING: Clipboard unavailable: {:?}", e);
                 return Ok(());
             }
         }
@@ -24,7 +24,7 @@ pub fn copy_to_clipboard(
         if fail_hard {
             return Err(anyhow::anyhow!("Clipboard copy failed: {:?}", e));
         } else {
-            tracing::warn!("⚠️  Clipboard copy failed: {:?}", e);
+            tracing::warn!("WARNING: Clipboard copy failed: {:?}", e);
         }
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,14 +166,14 @@ fn main() -> Result<()> {
         let summary = if config.stdout && config.no_clipboard && config.model_context.is_none() {
             // Skip tokenisation for pure stdout + no-clipboard runs when no model_context
             format!(
-                "✔ {} files • 1 chunk • copied={}",
+                "OK {} files • 1 chunk • copied={}",
                 file_data.len(),
                 if !config.no_clipboard { "0" } else { "none" }
             )
         } else {
             let token_count = gather::count_tokens(&xml_output);
             format!(
-                "✔ {} files • {} tokens • 1 chunk • copied={}",
+                "OK {} files • {} tokens • 1 chunk • copied={}",
                 file_data.len(),
                 token_count,
                 if !config.no_clipboard { "0" } else { "none" }
@@ -231,7 +231,7 @@ fn main() -> Result<()> {
     }
     // 8) Summary
     println!(
-        "✔ {} files • {} tokens • {} chunks • copied={}",
+        "OK {} files • {} tokens • {} chunks • copied={}",
         file_data.len(),
         count_tokens(&xml_output),
         chunks.len(),

--- a/src/ui/stream.rs
+++ b/src/ui/stream.rs
@@ -123,7 +123,7 @@ pub fn streaming_mode(
         }
         if !config.no_clipboard {
             clipboard::copy_to_clipboard(&snippet, false)?;
-            println!("✔ copied chunk {idx}");
+            println!("Copied chunk {idx}");
         }
         print!("Enter chunk # (0..{}) or 'q' to quit: ", total - 1);
         io::stdout().flush()?;

--- a/tests/cli_chunked.rs
+++ b/tests/cli_chunked.rs
@@ -19,6 +19,6 @@ fn chunk_size_splits_and_summarizes() {
         .success()
         .stdout(contains("<context-chunk id=\""))
         .stdout(contains("<more remaining=\"")) // the marker printed between chunks
-        .stdout(contains("✔")) // summary line
+        .stdout(contains("OK")) // summary line
         .stderr(predicates::str::is_empty());
 }

--- a/tests/cli_happy.rs
+++ b/tests/cli_happy.rs
@@ -34,6 +34,6 @@ fn chunk_size_splits_and_summarises() {
         .success()
         .stdout(contains("<context-chunk id="))
         .stdout(contains("<more remaining=\""))
-        .stdout(contains("✔")) // summary line
+        .stdout(contains("OK")) // summary line
         .stderr(predicates::str::is_empty());
 }


### PR DESCRIPTION
## Summary
- replace emoji warnings with ASCII text
- adjust output messages and tests to use `OK`

## Testing
- `cargo test` *(fails: failed to download from crates.io)*