### PR TITLE
Deduplicate gathered file paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,10 @@ fn main() -> Result<()> {
         candidate_files.extend(gather::gather_all_file_paths(&dirs_to_scan)?);
     }
 
+    // Deduplicate combined list of explicit files and scanned directories
+    candidate_files.sort();
+    candidate_files.dedup();
+
     // 3) Among those gathered, preselect anything "under" or exactly matching user
     //    paths
     let preselected_paths: Vec<PathBuf> = candidate_files

--- a/tests/cli_dedup.rs
+++ b/tests/cli_dedup.rs
@@ -1,0 +1,18 @@
+use assert_cmd::Command;
+use assert_fs::prelude::*;
+use predicates::str::{contains, is_empty};
+
+#[test]
+fn dir_and_file_are_deduped() {
+    let dir = assert_fs::TempDir::new().unwrap();
+    dir.child("foo.txt").write_str("hello").unwrap();
+
+    Command::cargo_bin("context-gather")
+        .unwrap()
+        .current_dir(&dir)
+        .args(["--stdout", "--no-clipboard", ".", "foo.txt"])
+        .assert()
+        .success()
+        .stdout(contains("✔ 1 files"))
+        .stderr(is_empty());
+}


### PR DESCRIPTION
## Summary
- deduplicate candidate files before preselection and other processing
- ensure specifying both a directory and a contained file results in one entry
- add regression test for deduping

## Testing
- `cargo test --locked --quiet` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0164b10833190b32c7c6b581010