### PR TITLE
Handle single-chunk output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,8 @@ fn main() -> Result<()> {
             let mut s = chunk.xml.clone();
             if rem > 0 {
                 s.push_str(&format!("<more remaining=\"{rem}\"/>\n"));
+            } else {
+                s.push_str("</shared-context>\n");
             }
             s
         } else if rem > 0 {

--- a/src/ui/stream.rs
+++ b/src/ui/stream.rs
@@ -105,6 +105,8 @@ pub fn streaming_mode(
             let mut s = chunks[0].xml.clone();
             if rem > 0 {
                 s.push_str(&format!("<more remaining=\"{}\"/>\n", rem));
+            } else {
+                s.push_str("</shared-context>\n");
             }
             s
         } else if rem > 0 {

--- a/tests/cli_chunked.rs
+++ b/tests/cli_chunked.rs
@@ -22,3 +22,19 @@ fn chunk_size_splits_and_summarizes() {
         .stdout(contains("✔")) // summary line
         .stderr(predicates::str::is_empty());
 }
+
+#[test]
+fn zero_files_outputs_header_with_closing_tag() {
+    let dir = assert_fs::TempDir::new().unwrap();
+
+    Command::cargo_bin("context-gather")
+        .unwrap()
+        .current_dir(&dir)
+        .args(["--stdout", "--no-clipboard", "-c", "50", "."])
+        .assert()
+        .success()
+        .stdout(contains("</shared-context>"))
+        .stdout(contains("<context-chunk id=").not())
+        .stdout(predicates::str::is_empty().not())
+        .stderr(predicates::str::is_empty());
+}


### PR DESCRIPTION
## Summary
- close `<shared-context>` if there is only the header chunk
- handle this in interactive and non-interactive modes
- test empty directory output closes the tag

## Testing
- `cargo test -q` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_684ab0226ab08331a4fcdc016ae89b13